### PR TITLE
fix(core): preserve anchors in project document links

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-comment-parts.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-comment-parts.ts
@@ -63,7 +63,8 @@ export function getCommentParts(
             } else {
               const fileName = this.page.project.files.getName(part.target);
               if (fileName) {
-                url = this.getRelativeUrl(`_media/${fileName}`);
+                const anchor = part.targetAnchor ? `#${part.targetAnchor}` : '';
+                url = this.getRelativeUrl(`_media/${fileName}${anchor}`);
               }
             }
 

--- a/packages/typedoc-plugin-markdown/test/fixtures/src/comments/index.ts
+++ b/packages/typedoc-plugin-markdown/test/fixtures/src/comments/index.ts
@@ -25,6 +25,7 @@
  * Relative Links:
  *
  * - [Relative Document](../../PROJECT_DOC_1.md)
+ * - [Relative Document With Anchor](../../PROJECT_DOC_1.md#anchor)
  *
  * Relative Image Links:
  *

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/comments.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/comments.spec.ts.snap
@@ -41,6 +41,7 @@ External links:
 Relative Links:
 
 - [Relative Document](_media/PROJECT_DOC_1.md)
+- [Relative Document With Anchor](_media/PROJECT_DOC_1.md#anchor)
 
 Relative Image Links:
 


### PR DESCRIPTION
I noticed that when referring to specific section of the project documents, anchors were missing.