### PR TITLE
fix(core): Move `isOptional` flag inside `backTicks`

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -32,13 +32,13 @@ Finally, you can build all the packages and run the tests to ensure everything i
 Build all packages in the workspace:
 
 ```bash
-npm run build
+npm run build-all
 ```
 
 Test all packages in the workspace:
 
 ```bash
-npm run test
+npm run test-all
 ```
 
 ## 2. Contributing to packages

--- a/devguide/documents/Getting-Started.md
+++ b/devguide/documents/Getting-Started.md
@@ -29,13 +29,13 @@ Finally, you can build all the packages and run the tests to ensure everything i
 Build all packages in the workspace:
 
 ```bash
-npm run build
+npm run build-all
 ```
 
 Test all packages in the workspace:
 
 ```bash
-npm run test
+npm run test-all
 ```
 
 ## 2. Contributing to packages

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.parametersTable.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.parametersTable.ts
@@ -77,7 +77,7 @@ export function parametersTable(
 
     const optional = isOptional ? '?' : '';
 
-    row.push(`${rest}${backTicks(parameter.name)}${optional}`);
+    row.push(`${rest}${backTicks(`${parameter.name}${optional}`)}`);
 
     if (parameter.type) {
       const displayType =

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
@@ -20,13 +20,12 @@ export function signatureParameters(
         }
         const paramType = this.partials.someType(param.type as SomeType);
         const showParamType = this.options.getValue('expandParameters');
+        const optional = param.flags.isOptional ||
+        (firstOptionalParamIndex !== -1 && i > firstOptionalParamIndex)
+          ? '?'
+          : ''
         const paramItem = [
-          `${backTicks(param.name)}${
-            param.flags.isOptional ||
-            (firstOptionalParamIndex !== -1 && i > firstOptionalParamIndex)
-              ? '?'
-              : ''
-          }`,
+          `${backTicks(`${param.name}${optional}`)}`,
         ];
         if (showParamType) {
           paramItem.push(paramType);

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.typeDeclarationTable.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.typeDeclarationTable.ts
@@ -73,7 +73,7 @@ export function typeDeclarationTable(
     }
 
     const name =
-      backTicks(`${declaration.name}${isSignature ? '()' : ''}`) + optional;
+      backTicks(`${declaration.name}${isSignature ? '()' : ''}${optional}`);
 
     nameColumn.push(name);
 

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/type.reflection.function.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/type.reflection.function.ts
@@ -22,9 +22,7 @@ export function functionType(
       ? fn.parameters.map((param) => {
           const paramType = this.partials.someType(param.type as SomeType);
           const paramItem = [
-            `${param.flags?.isRest ? '...' : ''}${backTicks(param.name)}${
-              param.flags?.isOptional ? '?' : ''
-            }`,
+            `${param.flags?.isRest ? '...' : ''}${backTicks(`${param.name}${param.flags?.isOptional ? '?' : ''}`)}`,
           ];
           if (showParameterType) {
             paramItem.push(paramType);

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/objects-and-params.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/objects-and-params.spec.ts.snap
@@ -119,7 +119,7 @@ Comments for propReturningSignatureDeclaration
 
 ### propReturningSignatureDeclarations
 
-> **propReturningSignatureDeclarations**: () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB\`?: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\`
+> **propReturningSignatureDeclarations**: () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB?\`: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\`
 
 Comments for propReturningSignatureDeclarations
 
@@ -219,7 +219,7 @@ Comments for BasicInterface
 | \`propReturningObjectDeclaration.b\` | \`string\` | - |
 | <a id="propreturningobjectdeclarations"></a> \`propReturningObjectDeclarations\` | \\{ \`a\`: \`boolean\`; \`b\`: \`string\`; \\} & \\{ \`c\`: \`boolean\`; \`d\`: \`string\`; \\} | Comments for propReturningObjectDeclarations |
 | <a id="propreturningsignaturedeclaration"></a> \`propReturningSignatureDeclaration?\` | () => \`string\` \\| \`number\` \\| \`boolean\` | Comments for propReturningSignatureDeclaration |
-| <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB\`?: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations |
+| <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB?\`: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations |
 | <a id="propwithfunction"></a> \`propWithFunction\` | (\`options\`: \\{ \`a\`: \`boolean\`; \`b\`: \`string\`; \\}) => \`boolean\` | Comments for propWithFunction |
 | <a id="propwithprops"></a> \`propWithProps\` | \\{ \`callbacks\`: \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\>; \`nestedPropA\`: \`string\`; \`nestedPropB\`: \`boolean\`; \`nestedPropC\`: \\{ \`nestedPropCA\`: \`string\`; \\}; \`nestedPropD\`: () => \`boolean\`; \\} | Comments for propWithProps |
 | \`propWithProps.callbacks?\` | \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\> | Comments for callbacks |
@@ -362,7 +362,7 @@ y: number = 2;
 exports[`Objects And Params should compile function with nested parameters: (Output File Strategy "members") (Option Group "1") 1`] = `
 "# Function: functionWithNestedParameters()
 
-> **functionWithNestedParameters**(\`params\`: \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\}, \`context\`: \`any\`, \`somethingElse\`?: \`string\`): \`boolean\`
+> **functionWithNestedParameters**(\`params\`: \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\}, \`context\`: \`any\`, \`somethingElse?\`: \`string\`): \`boolean\`
 
 Some nested params.
 
@@ -449,13 +449,13 @@ Some nested params.
 | \`params\` | \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\} | The parameters passed to the method. |
 | \`params.name\` | \`string\` | The name of the new group. |
 | \`params.nestedObj\` | \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\} | A nested object. |
-| \`params.nestedObj.name\`? | \`string\` | - |
-| \`params.nestedObj.obj\`? | \\{ \`name\`: () => \`void\`; \\} | - |
-| \`params.nestedObj.obj.name\`? | () => \`void\` | - |
-| \`params.nestedObj.value\`? | \`number\` | - |
-| \`params.parent\`? | \`number\` | - |
-| \`context\`? | \`any\` | The context of the method call. |
-| \`somethingElse\`? | \`string\` | - |
+| \`params.nestedObj.name?\` | \`string\` | - |
+| \`params.nestedObj.obj?\` | \\{ \`name\`: () => \`void\`; \\} | - |
+| \`params.nestedObj.obj.name?\` | () => \`void\` | - |
+| \`params.nestedObj.value?\` | \`number\` | - |
+| \`params.parent?\` | \`number\` | - |
+| \`context?\` | \`any\` | The context of the method call. |
+| \`somethingElse?\` | \`string\` | - |
 
 ## Returns
 

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/reflection.function.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/reflection.function.spec.ts.snap
@@ -381,13 +381,13 @@ Return comments
 
 ### member1
 
-> **member1**: \\{(\`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`signOutCallback\`?, \`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \`prop1\`: \`string\`; \`prop2\`: \`string\`; \\}
+> **member1**: \\{(\`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`signOutCallback?\`, \`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \`prop1\`: \`string\`; \`prop2\`: \`string\`; \\}
 
 Member 1 comments
 
 #### Call Signature
 
-> (\`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> (\`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Comments for function 1
 
@@ -403,7 +403,7 @@ Comments for function 1
 
 #### Call Signature
 
-> (\`signOutCallback\`?, \`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> (\`signOutCallback?\`, \`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Comments for function 2
 
@@ -435,11 +435,11 @@ Comments for prop 2
 
 ### member2()
 
-> **member2**: \\{(\`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`options2\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \\}
+> **member2**: \\{(\`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`options2?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \\}
 
 #### Call Signature
 
-> (\`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> (\`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Comments for function 1
 
@@ -455,7 +455,7 @@ Comments for function 1
 
 #### Call Signature
 
-> (\`options2\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> (\`options2?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Comments for function 2
 
@@ -471,7 +471,7 @@ Comments for function 2
 
 ### member3()
 
-> **member3**: (\`options\`?) => [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> **member3**: (\`options?\`) => [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Member 3 comments
 
@@ -516,11 +516,11 @@ Return comments
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| \`member1()\` | \\{ (\`options\`?: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`signOutCallback\`?: \`any\`, \`options\`?: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \`prop1\`: \`string\`; \`prop2\`: \`string\`; \\} | Member 1 comments Comments for function 1 Comments for function 2 |
+| \`member1()\` | \\{ (\`options?\`: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`signOutCallback?\`: \`any\`, \`options?\`: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \`prop1\`: \`string\`; \`prop2\`: \`string\`; \\} | Member 1 comments Comments for function 1 Comments for function 2 |
 | \`member1.prop1\` | \`string\` | Comments for prop 1 |
 | \`member1.prop2\` | \`string\` | Comments for prop 2 |
-| \`member2()\` | \\{ (\`options\`?: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`options2\`?: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \\} | Comments for function 1 Comments for function 2 |
-| \`member3()\` | (\`options\`?: \`any\`) => [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\> | Member 3 comments Comments for function |
+| \`member2()\` | \\{ (\`options?\`: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; (\`options2?\`: \`any\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>; \\} | Comments for function 1 Comments for function 2 |
+| \`member3()\` | (\`options?\`: \`any\`) => [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\> | Member 3 comments Comments for function |
 | \`member4\` | \`object\` | - |
 | \`member4.prop\` | \`string\` | Comments for prop |
 "
@@ -1038,8 +1038,8 @@ Defined in: [functions.ts:1](http://source-url)
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
 | \`__namedParameters\` | \\{ \`bar\`: \`number\`; \`foo\`: \`number\`; \\} | various options |
-| \`__namedParameters.bar\`? | \`number\` | - |
-| \`__namedParameters.foo\`? | \`number\` | - |
+| \`__namedParameters.bar?\` | \`number\` | - |
+| \`__namedParameters.foo?\` | \`number\` | - |
 | \`anotherParam\` | \`string\` | Another param comment |
 
 ## Returns
@@ -1051,7 +1051,7 @@ Defined in: [functions.ts:1](http://source-url)
 exports[`Function Reflection should compile function with nested parameters: (Output File Strategy "members") (Option Group "1") 1`] = `
 "# Function: functionWithNestedParameters()
 
-> **functionWithNestedParameters**(\`params\`, \`context\`, \`somethingElse\`?): \`boolean\`
+> **functionWithNestedParameters**(\`params\`, \`context\`, \`somethingElse?\`): \`boolean\`
 
 Defined in: [functions.ts:1](http://source-url)
 
@@ -1132,13 +1132,13 @@ Some nested params.
 | \`params\` | \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\} | The parameters passed to the method. |
 | \`params.name\` | \`string\` | The name of the new group. |
 | \`params.nestedObj\` | \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\} | A nested object. |
-| \`params.nestedObj.name\`? | \`string\` | - |
-| \`params.nestedObj.obj\`? | \\{ \`name\`: () => \`void\`; \\} | - |
-| \`params.nestedObj.obj.name\`? | () => \`void\` | - |
-| \`params.nestedObj.value\`? | \`number\` | - |
-| \`params.parent\`? | \`number\` | - |
-| \`context\`? | \`any\` | The context of the method call. |
-| \`somethingElse\`? | \`string\` | - |
+| \`params.nestedObj.name?\` | \`string\` | - |
+| \`params.nestedObj.obj?\` | \\{ \`name\`: () => \`void\`; \\} | - |
+| \`params.nestedObj.obj.name?\` | () => \`void\` | - |
+| \`params.nestedObj.value?\` | \`number\` | - |
+| \`params.parent?\` | \`number\` | - |
+| \`context?\` | \`any\` | The context of the method call. |
+| \`somethingElse?\` | \`string\` | - |
 
 ## Returns
 
@@ -1149,7 +1149,7 @@ Some nested params.
 exports[`Function Reflection should compile function with optional parameters: (Output File Strategy "members") (Option Group "1") 1`] = `
 "# Function: functionWithOptionalParameters()
 
-> **functionWithOptionalParameters**(\`firstParamWithDefault\`, \`requiredParam\`, \`optionalParam\`?, \`paramWithDefault\`?): \`void\`
+> **functionWithOptionalParameters**(\`firstParamWithDefault\`, \`requiredParam\`, \`optionalParam?\`, \`paramWithDefault?\`): \`void\`
 
 Defined in: [functions.ts:1](http://source-url)
 
@@ -1186,7 +1186,7 @@ An optional parameter.
 exports[`Function Reflection should compile function with optional parameters: (Output File Strategy "members") (Option Group "1") 2`] = `
 "# Function: functionWithOptionalParameters()
 
-> **functionWithOptionalParameters**(\`firstParamWithDefault\`, \`requiredParam\`, \`optionalParam\`?, \`paramWithDefault\`?): \`void\`
+> **functionWithOptionalParameters**(\`firstParamWithDefault\`, \`requiredParam\`, \`optionalParam?\`, \`paramWithDefault?\`): \`void\`
 
 Defined in: [functions.ts:1](http://source-url)
 
@@ -1241,8 +1241,8 @@ This is a function with a parameters.
 | :------ | :------ | :------ | :------ |
 | \`firstParamWithDefault\` | \`boolean\` | \`true\` | - |
 | \`requiredParam\` | \`string\` | \`undefined\` | A normal parameter. |
-| \`optionalParam\`? | \`string\` | \`undefined\` | An optional parameter. |
-| \`paramWithDefault\`? | \`number\` | \`0\` | - |
+| \`optionalParam?\` | \`string\` | \`undefined\` | An optional parameter. |
+| \`paramWithDefault?\` | \`number\` | \`0\` | - |
 
 ## Returns
 
@@ -1271,8 +1271,8 @@ This is a function with a parameters.
 | :------ | :------ | :------ | :------ |
 | \`firstParamWithDefault\` | \`boolean\` | \`true\` | - |
 | \`requiredParam\` | \`string\` | \`undefined\` | A normal parameter. |
-| \`optionalParam\`? | \`string\` | \`undefined\` | An optional parameter. |
-| \`paramWithDefault\`? | \`number\` | \`0\` | - |
+| \`optionalParam?\` | \`string\` | \`undefined\` | An optional parameter. |
+| \`paramWithDefault?\` | \`number\` | \`0\` | - |
 
 ## Returns
 

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/reflection.interface.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/reflection.interface.spec.ts.snap
@@ -139,7 +139,7 @@ Comments for propReturningSignatureDeclaration
 
 ### propReturningSignatureDeclarations
 
-> **propReturningSignatureDeclarations**: () => \`any\` & (\`paramsA\`, \`paramsB\`?) => \`any\` & (\`paramsC\`) => \`any\`
+> **propReturningSignatureDeclarations**: () => \`any\` & (\`paramsA\`, \`paramsB?\`) => \`any\` & (\`paramsC\`) => \`any\`
 
 Defined in: [interfaces.ts:1](http://source-url)
 
@@ -247,7 +247,7 @@ Comments for BasicInterface
 | \`propReturningObjectDeclaration.b\` | \`string\` | - |
 | <a id="propreturningobjectdeclarations"></a> \`propReturningObjectDeclarations\` | \`object\` & \`object\` | Comments for propReturningObjectDeclarations |
 | <a id="propreturningsignaturedeclaration"></a> \`propReturningSignatureDeclaration?\` | () => \`string\` \\| \`number\` \\| \`boolean\` | Comments for propReturningSignatureDeclaration |
-| <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB\`?: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations |
+| <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB?\`: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations |
 | <a id="propwithfunction"></a> \`propWithFunction\` | (\`options\`: \`object\`) => \`boolean\` | Comments for propWithFunction |
 | <a id="propwithprops"></a> \`propWithProps\` | \`object\` | Comments for propWithProps |
 | \`propWithProps.callbacks?\` | \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\> | Comments for callbacks |
@@ -434,7 +434,7 @@ Comments for propReturningSignatureDeclaration
 
 ### propReturningSignatureDeclarations
 
-> **propReturningSignatureDeclarations**: () => \`any\` & (\`paramsA\`, \`paramsB\`?) => \`any\` & (\`paramsC\`) => \`any\`
+> **propReturningSignatureDeclarations**: () => \`any\` & (\`paramsA\`, \`paramsB?\`) => \`any\` & (\`paramsC\`) => \`any\`
 
 Defined in: [interfaces.ts:1](http://source-url)
 
@@ -555,7 +555,7 @@ Comments for ExtendedInterface
 | \`propReturningObjectDeclaration.b\` | \`string\` | - | - |
 | <a id="propreturningobjectdeclarations"></a> \`propReturningObjectDeclarations\` | \`object\` & \`object\` | Comments for propReturningObjectDeclarations | [\`BasicInterface\`](BasicInterface.md).[\`propReturningObjectDeclarations\`](BasicInterface.md#propreturningobjectdeclarations) |
 | <a id="propreturningsignaturedeclaration"></a> \`propReturningSignatureDeclaration?\` | () => \`string\` \\| \`number\` \\| \`boolean\` | Comments for propReturningSignatureDeclaration | [\`BasicInterface\`](BasicInterface.md).[\`propReturningSignatureDeclaration\`](BasicInterface.md#propreturningsignaturedeclaration) |
-| <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB\`?: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations | [\`BasicInterface\`](BasicInterface.md).[\`propReturningSignatureDeclarations\`](BasicInterface.md#propreturningsignaturedeclarations) |
+| <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB?\`: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations | [\`BasicInterface\`](BasicInterface.md).[\`propReturningSignatureDeclarations\`](BasicInterface.md#propreturningsignaturedeclarations) |
 | <a id="propwithfunction"></a> \`propWithFunction\` | (\`options\`: \`object\`) => \`boolean\` | Comments for propWithFunction | [\`BasicInterface\`](BasicInterface.md).[\`propWithFunction\`](BasicInterface.md#propwithfunction) |
 | <a id="propwithprops"></a> \`propWithProps\` | \`object\` | Comments for propWithProps | [\`BasicInterface\`](BasicInterface.md).[\`propWithProps\`](BasicInterface.md#propwithprops) |
 | \`propWithProps.callbacks?\` | \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\> | Comments for callbacks | - |
@@ -830,7 +830,7 @@ Comments for InterfaceWithFunction
 
 ## Call Signature
 
-> **InterfaceWithFunctionOverloads**(\`options\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> **InterfaceWithFunctionOverloads**(\`options?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Defined in: [interfaces.ts:1](http://source-url)
 
@@ -848,7 +848,7 @@ Comments for InterfaceWithFunction
 
 ## Call Signature
 
-> **InterfaceWithFunctionOverloads**(\`options2\`?): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
+> **InterfaceWithFunctionOverloads**(\`options2?\`): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`void\`\\>
 
 Defined in: [interfaces.ts:1](http://source-url)
 
@@ -887,7 +887,7 @@ Comments for InterfaceWithFunction
 
 | Parameter | Type |
 | :------ | :------ |
-| \`options\`? | \`any\` |
+| \`options?\` | \`any\` |
 
 ### Returns
 
@@ -907,7 +907,7 @@ Comments for InterfaceWithFunction
 
 | Parameter | Type |
 | :------ | :------ |
-| \`options2\`? | \`any\` |
+| \`options2?\` | \`any\` |
 
 ### Returns
 


### PR DESCRIPTION
Hello!

As discussed in https://github.com/typedoc2md/typedoc-plugin-markdown/discussions/796 I'm putting up this PR to move occurrences of the `?` / `isOptional` flag inside any `backTicks` call. Previously it was inconsistent and sometimes inside, sometimes outside.