### PR TITLE
fix(core): format of optional type and getter/setter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22739,14 +22739,14 @@
       "version": "2.1.0",
       "license": "MIT",
       "peerDependencies": {
-        "typedoc-plugin-markdown": ">=4.6.1"
+        "typedoc-plugin-markdown": ">=4.6.2"
       }
     },
     "packages/typedoc-gitlab-wiki-theme": {
       "version": "2.1.0",
       "license": "MIT",
       "peerDependencies": {
-        "typedoc-plugin-markdown": ">=4.6.1"
+        "typedoc-plugin-markdown": ">=4.6.2"
       }
     },
     "packages/typedoc-plugin-frontmatter": {
@@ -22756,11 +22756,11 @@
         "yaml": "^2.7.0"
       },
       "peerDependencies": {
-        "typedoc-plugin-markdown": ">=4.6.1"
+        "typedoc-plugin-markdown": ">=4.6.2"
       }
     },
     "packages/typedoc-plugin-markdown": {
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -22781,14 +22781,14 @@
         "unist-util-visit": "^5.0.0"
       },
       "peerDependencies": {
-        "typedoc-plugin-markdown": ">=4.6.1"
+        "typedoc-plugin-markdown": ">=4.6.2"
       }
     },
     "packages/typedoc-vitepress-theme": {
       "version": "1.1.2",
       "license": "MIT",
       "peerDependencies": {
-        "typedoc-plugin-markdown": ">=4.6.1"
+        "typedoc-plugin-markdown": ">=4.6.2"
       }
     }
   }

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
@@ -5,6 +5,7 @@ import { ParameterReflection, SomeType } from 'typedoc';
 export function signatureParameters(
   this: MarkdownThemeContext,
   model: ParameterReflection[],
+  options?: { forceExpandParameters?: boolean },
 ) {
   const format = this.options.getValue('useCodeBlocks');
   const firstOptionalParamIndex = model.findIndex(
@@ -19,14 +20,15 @@ export function signatureParameters(
           paramsmd.push('...');
         }
         const paramType = this.partials.someType(param.type as SomeType);
-        const showParamType = this.options.getValue('expandParameters');
-        const optional = param.flags.isOptional ||
-        (firstOptionalParamIndex !== -1 && i > firstOptionalParamIndex)
-          ? '?'
-          : ''
-        const paramItem = [
-          `${backTicks(`${param.name}${optional}`)}`,
-        ];
+        const showParamType =
+          (options?.forceExpandParameters ?? false) ||
+          this.options.getValue('expandParameters');
+        const optional =
+          param.flags.isOptional ||
+          (firstOptionalParamIndex !== -1 && i > firstOptionalParamIndex)
+            ? '?'
+            : '';
+        const paramItem = [`${backTicks(`${param.name}${optional}`)}`];
         if (showParamType) {
           paramItem.push(paramType);
         }

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/type.reflection.declaration.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/type.reflection.declaration.ts
@@ -41,15 +41,20 @@ export function declarationType(
 
         if (obj.getSignature) {
           name.push('get');
-          name.push(backTicks(obj.name) + '\n ');
-        }
-
-        if (obj.setSignature) {
+          name.push(backTicks(obj.name) + '()');
+        } else if (obj.setSignature) {
           name.push('set');
-          name.push(backTicks(obj.name));
+          const params = obj.setSignature.parameters
+            ? this.partials.signatureParameters(obj.setSignature.parameters, {
+                forceExpandParameters: true,
+              })
+            : '()';
+          name.push(backTicks(obj.name) + params);
+        } else {
+          const displayObjectName =
+            obj.name + (obj.flags?.isOptional ? '?' : '');
+          name.push(backTicks(displayObjectName));
         }
-
-        name.push(backTicks(obj.name));
 
         const theType = this.helpers.getDeclarationType(obj) as SomeType;
 
@@ -67,6 +72,7 @@ export function declarationType(
       );
     }
   }
+
   md.push(`${shouldFormat ? '' : ' '}\\}`);
   return md.join(shouldFormat ? '\n' : '');
 }

--- a/packages/typedoc-plugin-markdown/src/theme/context/resources.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/resources.ts
@@ -160,8 +160,11 @@ There is no association list partial for properties as these are handled as a st
         hideTitle?: boolean | undefined;
       },
     ) => partials.signature.apply(context, [model, options]) as string,
-    signatureParameters: (model: ParameterReflection[]) =>
-      partials.signatureParameters.apply(context, [model]) as string,
+    signatureParameters: (
+      model: ParameterReflection[],
+      options?: { forceExpandParameters?: boolean | undefined } | undefined,
+    ) =>
+      partials.signatureParameters.apply(context, [model, options]) as string,
     signatureReturns: (
       model: SignatureReflection,
       options: { headingLevel: number },

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/objects-and-params.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/objects-and-params.spec.ts.snap
@@ -151,7 +151,7 @@ Comments for propWithFunction
 
 ### propWithProps
 
-> **propWithProps**: \\{ \`callbacks\`: \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\>; \`nestedPropA\`: \`string\`; \`nestedPropB\`: \`boolean\`; \`nestedPropC\`: \\{ \`nestedPropCA\`: \`string\`; \\}; \`nestedPropD\`: () => \`boolean\`; \\}
+> **propWithProps**: \\{ \`callbacks?\`: \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\>; \`nestedPropA\`: \`string\`; \`nestedPropB\`: \`boolean\`; \`nestedPropC\`: \\{ \`nestedPropCA\`: \`string\`; \\}; \`nestedPropD\`: () => \`boolean\`; \\}
 
 Comments for propWithProps
 
@@ -221,7 +221,7 @@ Comments for BasicInterface
 | <a id="propreturningsignaturedeclaration"></a> \`propReturningSignatureDeclaration?\` | () => \`string\` \\| \`number\` \\| \`boolean\` | Comments for propReturningSignatureDeclaration |
 | <a id="propreturningsignaturedeclarations"></a> \`propReturningSignatureDeclarations\` | () => \`any\` & (\`paramsA\`: \`true\` \\| \`any\`[], \`paramsB?\`: \`any\`) => \`any\` & (\`paramsC\`: \`any\`) => \`any\` | Comments for propReturningSignatureDeclarations |
 | <a id="propwithfunction"></a> \`propWithFunction\` | (\`options\`: \\{ \`a\`: \`boolean\`; \`b\`: \`string\`; \\}) => \`boolean\` | Comments for propWithFunction |
-| <a id="propwithprops"></a> \`propWithProps\` | \\{ \`callbacks\`: \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\>; \`nestedPropA\`: \`string\`; \`nestedPropB\`: \`boolean\`; \`nestedPropC\`: \\{ \`nestedPropCA\`: \`string\`; \\}; \`nestedPropD\`: () => \`boolean\`; \\} | Comments for propWithProps |
+| <a id="propwithprops"></a> \`propWithProps\` | \\{ \`callbacks?\`: \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\>; \`nestedPropA\`: \`string\`; \`nestedPropB\`: \`boolean\`; \`nestedPropC\`: \\{ \`nestedPropCA\`: \`string\`; \\}; \`nestedPropD\`: () => \`boolean\`; \\} | Comments for propWithProps |
 | \`propWithProps.callbacks?\` | \`Partial\`\\<[\`CallbacksOptions\`](../classes/CallbacksOptions.md)\\<[\`DisposableClass\`](../classes/DisposableClass.md), [\`ClassWithModifiers\`](../classes/ClassWithModifiers.md)\\>\\> | Comments for callbacks |
 | \`propWithProps.nestedPropA\` | \`string\` | Comments for nestedPropA |
 | \`propWithProps.nestedPropB\` | \`boolean\` | Comments for nestedPropB |
@@ -362,7 +362,7 @@ y: number = 2;
 exports[`Objects And Params should compile function with nested parameters: (Output File Strategy "members") (Option Group "1") 1`] = `
 "# Function: functionWithNestedParameters()
 
-> **functionWithNestedParameters**(\`params\`: \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\}, \`context\`: \`any\`, \`somethingElse?\`: \`string\`): \`boolean\`
+> **functionWithNestedParameters**(\`params\`: \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent?\`: \`number\`; \\}, \`context\`: \`any\`, \`somethingElse?\`: \`string\`): \`boolean\`
 
 Some nested params.
 
@@ -434,7 +434,7 @@ function functionWithNestedParameters(
      };
      value: number;
   };
-  parent: number;
+  parent?: number;
 }, 
    context: any, 
    somethingElse?: string): boolean;
@@ -446,7 +446,7 @@ Some nested params.
 
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
-| \`params\` | \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\} | The parameters passed to the method. |
+| \`params\` | \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent?\`: \`number\`; \\} | The parameters passed to the method. |
 | \`params.name\` | \`string\` | The name of the new group. |
 | \`params.nestedObj\` | \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\} | A nested object. |
 | \`params.nestedObj.name?\` | \`string\` | - |
@@ -502,9 +502,7 @@ bar: number;
 exports[`Objects And Params should compile literal type: (Output File Strategy "members") (Option Group "1") 1`] = `
 "# Type Alias: LiteralType
 
-> **LiteralType** = \\{ \`someFunctionWithArrow\`: () => \`string\`; \`x\`: \`string\`; \`y\`: \\{ \`x\`: \`string\`; \`y\`: \`boolean\` \\| \`string\`; \`z\`: (\`x\`: \`string\`) => \`string\`; \\}; \`z\`: (\`x\`: \`string\`) => \`string\`; get \`accessorA\`
-  set \`accessorA\` \`accessorA\`: [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`string\`\\>; get \`accessorB\`
-  set \`accessorB\` \`accessorB\`: \`string\`; \`someFunction\`: [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`any\`\\>; \\}
+> **LiteralType** = \\{ \`someFunctionWithArrow\`: () => \`string\`; \`x?\`: \`string\`; \`y\`: \\{ \`x\`: \`string\`; \`y?\`: \`boolean\` \\| \`string\`; \`z\`: (\`x\`: \`string\`) => \`string\`; \\}; \`z\`: (\`x\`: \`string\`) => \`string\`; get \`accessorA\`(): [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`string\`\\>; get \`accessorB\`(): \`string\`; \`someFunction\`: [\`Promise\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)\\<\`any\`\\>; \\}
 
 Comments for LiteralType
 
@@ -532,7 +530,7 @@ comment for x
 
 ### y
 
-> **y**: \\{ \`x\`: \`string\`; \`y\`: \`boolean\` \\| \`string\`; \`z\`: (\`x\`: \`string\`) => \`string\`; \\}
+> **y**: \\{ \`x\`: \`string\`; \`y?\`: \`boolean\` \\| \`string\`; \`z\`: (\`x\`: \`string\`) => \`string\`; \\}
 
 comment for y
 
@@ -662,17 +660,15 @@ exports[`Objects And Params should compile literal type: (Output File Strategy "
 \`\`\`ts
 type LiteralType = {
   someFunctionWithArrow: () => string;
-  x: string;
+  x?: string;
   y: {
      x: string;
-     y: boolean | string;
+     y?: boolean | string;
      z: (x: string) => string;
   };
   z: (x: string) => string;
-  get accessorA
-  set accessorA accessorA: Promise<string>;
-  get accessorB
-  set accessorB accessorB: string;
+  get accessorA(): Promise<string>;
+  get accessorB(): string;
   someFunction: Promise<any>;
 };
 \`\`\`
@@ -710,7 +706,7 @@ comment for x
 \`\`\`ts
 y: {
   x: string;
-  y: boolean | string;
+  y?: boolean | string;
   z: (x: string) => string;
 };
 \`\`\`

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/reflection.function.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/reflection.function.spec.ts.snap
@@ -1101,7 +1101,7 @@ Defined in: [functions.ts:1](http://source-url)
 
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
-| \`__namedParameters\` | \\{ \`bar\`: \`number\`; \`foo\`: \`number\`; \\} | various options |
+| \`__namedParameters\` | \\{ \`bar?\`: \`number\`; \`foo?\`: \`number\`; \\} | various options |
 | \`__namedParameters.bar?\` | \`number\` | - |
 | \`__namedParameters.foo?\` | \`number\` | - |
 | \`anotherParam\` | \`string\` | Another param comment |
@@ -1193,7 +1193,7 @@ Some nested params.
 
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
-| \`params\` | \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent\`: \`number\`; \\} | The parameters passed to the method. |
+| \`params\` | \\{ \`name\`: \`string\`; \`nestedObj\`: \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\}; \`parent?\`: \`number\`; \\} | The parameters passed to the method. |
 | \`params.name\` | \`string\` | The name of the new group. |
 | \`params.nestedObj\` | \\{ \`name\`: \`string\`; \`obj\`: \\{ \`name\`: () => \`void\`; \\}; \`value\`: \`number\`; \\} | A nested object. |
 | \`params.nestedObj.name?\` | \`string\` | - |


### PR DESCRIPTION
- A naive fix for formatting issue when optional or getter/setter properties used
- All example below was generated with `useCodeBlock` on

## Type with an optional

current the plugin formats optional type in type declaration like so:

code:

```typescript
export type TypeHasOptional = {
  foo?: string;
};
```

before the change it generates:

```ts
type TypeHasOptional = {
  foo: string;
};
```

after the change it generates:
```ts
type TypeHasOptional = {
  foo?: string;
};
```

## Type with a getter

code: 

```typescript
export type TypeHasGetter = {
  get foo(): string | undefined;
};
```

before the change it generates:

```ts
type TypeHasGetter = {
  get foo
  foo: undefined | string;
};
```

afterward:

```ts
type TypeHasGetter = {
  get foo(): undefined | string;
};
```

## Type with a setter

code:

```typescript
export type TypeHasSetter = {
  set foo(value: string | undefined);
};
```

before the change it generates:

```ts
type TypeHasSetter = {
  set foo foo: void;
};
```

afterward:

```ts
type TypeHasSetter = {
  set foo(value: undefined | string): void;
};
```