### PR TITLE
fix(core): correct return type of `helpers.getKeyword`

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-keyword.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-keyword.ts
@@ -1,6 +1,6 @@
 import { ReflectionKind } from 'typedoc';
 
-export function getKeyword(model: ReflectionKind): string {
+export function getKeyword(model: ReflectionKind): string | undefined {
   const KEYWORD_MAP = {
     [ReflectionKind.Class]: 'class',
     [ReflectionKind.Enum]: 'enum',

--- a/packages/typedoc-plugin-markdown/src/theme/context/resources.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/resources.ts
@@ -320,7 +320,7 @@ export const resourceHelpers = (context: MarkdownThemeContext) => {
       options?: { isTarget: boolean } | undefined,
     ) => helpers.getHierarchyType.apply(context, [model, options]) as string,
     getKeyword: (model: ReflectionKind) =>
-      helpers.getKeyword.apply(context, [model]) as string,
+      helpers.getKeyword.apply(context, [model]) as string | undefined,
     getModifier: (model: DeclarationReflection) =>
       helpers.getModifier.apply(context, [model]) as string | null,
     getParameterDefaultValue: (model: ParameterReflection) =>


### PR DESCRIPTION
`getKeyword` doesn't not handle all `ReflectionKind`, thus it should return a string _or an undefined_. 