### PR TITLE
fix: error when function plugin is used

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/plugin.ts
+++ b/packages/docusaurus-plugin-typedoc/src/plugin.ts
@@ -23,6 +23,7 @@ export default async function pluginDocusaurus(
             // Check PluginConfig is typed to ['docusaurus-plugin-typedoc', PluginOptions]
             if (
               pluginConfig &&
+              typeof pluginConfig[0] === 'string' &&
               pluginConfig[0].includes('docusaurus-plugin-typedoc') &&
               typeof pluginConfig[1] === 'object'
             ) {


### PR DESCRIPTION
If I include a `() => Plugin` type in the `plugins` array of the Docusaurus config, which is valid, then this code currently throws.