### PR TITLE
fix(core): resolve Prettier config against the file being written (#881)

### DIFF
--- a/.changeset/hungry-buttons-refuse.md
+++ b/.changeset/hungry-buttons-refuse.md
@@ -1,0 +1,5 @@
+---
+'typedoc-plugin-markdown': patch
+---
+
+- `formatWithPrettier` now resolves Prettier config against the file being written and reads `.editorconfig`, so path-specific settings are honoured (#881).

--- a/packages/typedoc-plugin-markdown/src/renderer/prettier.spec.ts
+++ b/packages/typedoc-plugin-markdown/src/renderer/prettier.spec.ts
@@ -1,0 +1,71 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Renderer } from 'typedoc';
+import { formatWithPrettierIfAvailable } from './prettier.js';
+
+/**
+ * `.editorconfig` resolution itself is covered by the `utils` fixtures, which
+ * publish the same page with and without a matching section. These specs cover
+ * the precedence rules that a single published output cannot express.
+ */
+
+const CONTENTS = [
+  '```ts',
+  'const someVeryLongVariableName = someFunction(argumentOne, argumentTwo, argumentThree);',
+  '```',
+  '',
+].join('\n');
+
+const EDITORCONFIG = 'root = true\n\n[*.md]\nmax_line_length = off\n';
+
+function mockRenderer(prettierConfigFile?: string) {
+  return {
+    application: {
+      logger: { warn: () => {}, verbose: () => {} },
+      options: { getValue: () => prettierConfigFile ?? '' },
+    },
+  } as unknown as Renderer;
+}
+
+function mockProject(files: Record<string, string>) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tpm-prettier-'));
+  Object.entries(files).forEach(([name, contents]) => {
+    fs.writeFileSync(path.join(dir, name), contents);
+  });
+  return path.join(dir, 'doc.md');
+}
+
+describe('typedoc-plugin-markdown (Renderer / formatWithPrettierIfAvailable)', () => {
+  it('should give a resolved Prettier config precedence over `.editorconfig`', async () => {
+    const fileName = mockProject({
+      '.editorconfig': EDITORCONFIG,
+      '.prettierrc.json': JSON.stringify({ printWidth: 40 }),
+    });
+    const out = await formatWithPrettierIfAvailable(
+      mockRenderer(),
+      CONTENTS,
+      fileName,
+    );
+    assert.ok(
+      out.includes('someFunction(\n'),
+      'expected `.prettierrc` to override `.editorconfig`',
+    );
+  });
+
+  it('should give an explicit `prettierConfigFile` precedence over `.editorconfig`', async () => {
+    const fileName = mockProject({ '.editorconfig': EDITORCONFIG });
+    const configFile = path.join(path.dirname(fileName), 'custom.json');
+    fs.writeFileSync(configFile, JSON.stringify({ printWidth: 40 }));
+    const out = await formatWithPrettierIfAvailable(
+      mockRenderer(configFile),
+      CONTENTS,
+      fileName,
+    );
+    assert.ok(
+      out.includes('someFunction(\n'),
+      'expected the configured file to override `.editorconfig`',
+    );
+  });
+});

--- a/packages/typedoc-plugin-markdown/src/renderer/prettier.ts
+++ b/packages/typedoc-plugin-markdown/src/renderer/prettier.ts
@@ -6,6 +6,7 @@ import { Renderer } from 'typedoc';
 export async function formatWithPrettierIfAvailable(
   renderer: Renderer,
   contents: string,
+  fileName: string,
 ) {
   const prettier = await getPrettier();
   if (!prettier) {
@@ -27,12 +28,18 @@ export async function formatWithPrettierIfAvailable(
     return contents;
   }
 
-  const prettierConfigPath =
-    renderer.application.options.getValue('prettierConfigFile') ||
-    process.cwd();
+  const prettierConfigFile = renderer.application.options.getValue(
+    'prettierConfigFile',
+  ) as string;
 
-  // Resolve Prettier configuration
-  const config = await prettier.resolveConfig(prettierConfigPath);
+  /**
+   * Resolve Prettier configuration against the file being written, so that
+   * path-specific config (and `.editorconfig` sections such as `[*.md]`) apply.
+   */
+  const config = await prettier.resolveConfig(fileName, {
+    editorconfig: true,
+    ...(prettierConfigFile ? { config: prettierConfigFile } : {}),
+  });
 
   // Format code using Prettier
   const formattedCode = prettier.format(contents, {

--- a/packages/typedoc-plugin-markdown/src/renderer/render.ts
+++ b/packages/typedoc-plugin-markdown/src/renderer/render.ts
@@ -261,6 +261,7 @@ async function renderDocument(
       pageEvent.contents = await formatWithPrettierIfAvailable(
         renderer,
         pageEvent.contents,
+        pageEvent.filename,
       );
     });
   }

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.brackets-classes-ClassWithChars.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.brackets-classes-ClassWithChars.md.snap
@@ -1,0 +1,27 @@
+# Class: ClassWithChars&lt;T&gt;
+
+## Type Parameters
+
+| Type Parameter |
+| -------------- |
+| `T`            |
+
+## Constructors
+
+### Constructor
+
+```ts
+new ClassWithChars<T>(): ClassWithChars<T>;
+```
+
+#### Returns
+
+`ClassWithChars`&lt;`T`&gt;
+
+## Properties
+
+### prop
+
+```ts
+prop: T;
+```

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.brackets-interfaces-InterfaceWithChars.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.brackets-interfaces-InterfaceWithChars.md.snap
@@ -1,0 +1,39 @@
+# Interface: InterfaceWithChars&lt;T&gt;
+
+## Type Parameters
+
+| Type Parameter |
+| -------------- |
+| `T`            |
+
+## Properties
+
+### &lt;
+
+```ts
+<: string;
+```
+
+---
+
+### &lt;tag&gt;
+
+```ts
+<tag>: string;
+```
+
+---
+
+### &gt;
+
+```ts
+>: string;
+```
+
+---
+
+### prop
+
+```ts
+prop: T;
+```

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.brackets-variables-variableWithChars.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.brackets-variables-variableWithChars.md.snap
@@ -1,0 +1,29 @@
+# Variable: variableWithChars
+
+```ts
+const variableWithChars: {
+  <x>: string;
+  <y>: string;
+  <z>: string;
+};
+```
+
+## Type Declaration
+
+### &lt;x&gt;
+
+```ts
+<x>: string = '>';
+```
+
+### &lt;y&gt;
+
+```ts
+<y>: string = '<';
+```
+
+### &lt;z&gt;
+
+```ts
+<z>: string = '<tag>';
+```

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.constructor-override-classes-Cache.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.constructor-override-classes-Cache.md.snap
@@ -1,0 +1,27 @@
+# Class: Cache
+
+## Extends
+
+- `LRUCache`&lt;`CacheFetchContext`, `CacheFetchContext`, `CacheFetchContext`&gt;
+
+## Constructors
+
+### Constructor
+
+```ts
+new Cache(): Cache;
+```
+
+#### Returns
+
+`Cache`
+
+#### Overrides
+
+```ts
+LRUCache<
+  CacheFetchContext,
+  CacheFetchContext,
+  CacheFetchContext
+>.constructor
+```

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.index-signature-type-aliases-LongIndexSignature.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.index-signature-type-aliases-LongIndexSignature.md.snap
@@ -1,0 +1,27 @@
+# Type Alias: LongIndexSignature
+
+```ts
+type LongIndexSignature = {
+  [
+    key:
+      | `git·${string}·${string} ${string}`
+      | `remote·${string}·${string} ${string}`
+  ]:
+    | `dev git·${string}·${string}`
+    | `dev remote·${string}·${string}`
+    | `prod git·${string}·${string}`
+    | `prod remote·${string}·${string}`;
+};
+```
+
+## Index Signature
+
+```ts
+[key:
+  | `git·${string}·${string} ${string}`
+  | `remote·${string}·${string} ${string}`]:
+  | `dev git·${string}·${string}`
+  | `dev remote·${string}·${string}`
+  | `prod git·${string}·${string}`
+  | `prod remote·${string}·${string}`
+```

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.prettier-functions-some_prettier_function.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.prettier-functions-some_prettier_function.md.snap
@@ -1,0 +1,32 @@
+# Function: some_prettier_function()
+
+```ts
+function some_prettier_function(
+  param,
+): string;
+```
+
+```ts
+reallyUgly(javascript);
+```
+
+```ts
+const originalSingleQuote = "hello";
+const originalDoubleQuote = "hello";
+```
+
+```css
+.h1 {
+  color: red;
+}
+```
+
+## Parameters
+
+| Parameter | Type     |
+| --------- | -------- |
+| `param`   | `string` |
+
+## Returns
+
+`string`

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.prettier-type-aliases-SomePrettierTypeAlias.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/utils/utils.members.opts-3.prettier-type-aliases-SomePrettierTypeAlias.md.snap
@@ -1,0 +1,13 @@
+# Type Alias: SomePrettierTypeAlias
+
+```ts
+type SomePrettierTypeAlias =
+  | string
+  | {
+      x: 1;
+    }
+  | boolean
+  | {
+      y: 2;
+    };
+```

--- a/packages/typedoc-plugin-markdown/test/fixtures/.editorconfig
+++ b/packages/typedoc-plugin-markdown/test/fixtures/.editorconfig
@@ -1,0 +1,8 @@
+# Isolates fixture output from the repository `.editorconfig`, so generated
+# Markdown does not shift when that file changes.
+root = true
+
+# Exercises `formatWithPrettier` resolving `.editorconfig` for the file being
+# written. Scoped to a single output so other fixtures keep Prettier defaults.
+[out/md/utils/**/opts-3/**/*.md]
+max_line_length = 40

--- a/packages/typedoc-plugin-markdown/test/fixtures/configs/utils.cjs
+++ b/packages/typedoc-plugin-markdown/test/fixtures/configs/utils.cjs
@@ -22,6 +22,12 @@ const opts2 = {
   prettierConfigFile: './test/fixtures/prettier-config/.prettierrc.json',
 };
 
+// Identical to `opts2`, but written to a path covered by a `.editorconfig`
+// section. Pinning the same config file keeps `printWidth` the only variable.
+const opts3 = {
+  ...opts2,
+};
+
 /** @type {import('typedoc').TypeDocOptions} */
 module.exports = {
   ...baseOptions,
@@ -43,6 +49,13 @@ module.exports = {
     },
     {
       name: 'markdown',
+      path: '../out/md/utils/members/opts-3',
+      options: {
+        ...opts3,
+      },
+    },
+    {
+      name: 'markdown',
       path: '../out/md/utils/modules/opts-1',
       options: {
         router: 'module',
@@ -55,6 +68,14 @@ module.exports = {
       options: {
         router: 'module',
         ...opts2,
+      },
+    },
+    {
+      name: 'markdown',
+      path: '../out/md/utils/modules/opts-3',
+      options: {
+        router: 'module',
+        ...opts3,
       },
     },
   ],


### PR DESCRIPTION
Fixes #881.

## The bug

`formatWithPrettier` resolved config like this:

```ts
const prettierConfigPath =
  renderer.application.options.getValue('prettierConfigFile') || process.cwd();

const config = await prettier.resolveConfig(prettierConfigPath);
```

Two problems:

1. `editorconfig: true` is missing, so `.editorconfig` was never read — this is what the issue reports.
2. The first argument to `resolveConfig` is **the file about to be formatted**, not a place to look for config. It was being passed either the config file itself (e.g. `./.prettierrc.json`) or a directory. Neither matches a `[*.md]` section, so adding `editorconfig: true` alone would not have fixed the report — only a bare `[*]` section would ever have applied.

## The fix

Resolve against the page filename, and pass `prettierConfigFile` through the `config` option it was always meant to use:

```ts
const config = await prettier.resolveConfig(fileName, {
  editorconfig: true,
  ...(prettierConfigFile ? { config: prettierConfigFile } : {}),
});
```

`render.ts` already had `pageEvent.filename` on hand and now passes it through. Path-specific `overrides` in a `.prettierrc` also start working as a side effect.

## Tests

Follows the fixture convention — publish output, then match it. A new `utils` `opts-3` output is defined as `{ ...opts2 }`, so the only variable against `opts-2` is a scoped `.editorconfig` section:

```ini
[out/md/utils/**/opts-3/**/*.md]
max_line_length = 40
```

The published diff is entirely print width:

```
opts-2:  function some_prettier_function(param): string;
opts-3:  function some_prettier_function(
           param,
         ): string;
```

`test/fixtures/.editorconfig` also sets `root = true`, so fixture output no longer inherits the repository's own `.editorconfig`. Without it, generated Markdown silently picks up the repo's `[*.md] max_line_length = off` and existing snapshots shift. With it, **no existing snapshot changed** — only the 7 new `opts-3` ones.

Two precedence cases can't be expressed by a single published output, so they stay as unit specs in `src/renderer/prettier.spec.ts`: `.prettierrc` overriding `.editorconfig`, and an explicit `prettierConfigFile` overriding it.

225 passing. `eslint ./src` and `npm run validate` clean.

## Note for the release

This reflows generated Markdown for anyone with a `.editorconfig`, so upgraders will see a diff in committed docs. That is the fix working as intended, but it is a visible change from a `patch` bump — flagging in case you would rather it went out as `minor`.

Worth knowing for future fixtures: `root = true` stops `.editorconfig` traversal only. Prettier's own config search keeps walking up, so a fixture enabling `formatWithPrettier` without an explicit `prettierConfigFile` will silently read the repository's `.prettierrc.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)