### PR TITLE
chore(release): date changelog headings and sync docs copies automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,17 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Date the published changelog entries
+      - name: Date and sync the published changelogs
         if: steps.changesets.outputs.published == 'true'
         run: |
           node ./devtools/scripts/changelog-dates.mjs
+          node ./devtools/scripts/changelog-sync.mjs
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/*/CHANGELOG.md
+          git add packages/*/CHANGELOG.md docs/content
           if git diff --staged --quiet; then
-            echo "No undated changelog headings to commit"
+            echo "No changelog updates to commit"
             exit 0
           fi
-          git commit -m "chore(release): add release dates to changelogs [skip ci]"
+          git commit -m "chore(release): date and sync changelogs [skip ci]"
           git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,16 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Date the published changelog entries
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          node ./devtools/scripts/changelog-dates.mjs
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/*/CHANGELOG.md
+          if git diff --staged --quiet; then
+            echo "No undated changelog headings to commit"
+            exit 0
+          fi
+          git commit -m "chore(release): add release dates to changelogs [skip ci]"
+          git push origin HEAD:${{ github.ref_name }}

--- a/devtools/scripts/changelog-dates.mjs
+++ b/devtools/scripts/changelog-dates.mjs
@@ -1,0 +1,49 @@
+import { consola } from 'consola';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Appends the release date to the heading Changesets has written, as
+ * `## 1.2.3 (2026-08-25)`. Changesets writes the version alone, so the Release
+ * workflow runs this once packages have actually been published, and commits
+ * the result back. The date therefore reflects the publish, not the point the
+ * release PR was opened.
+ *
+ * Only the topmost heading is considered, and only when it has no date, so the
+ * script is safe to re-run and leaves earlier entries untouched.
+ */
+
+const PACKAGES_DIR = 'packages';
+const HEADING = /^## (\d+\.\d+\.\d+[^\s]*)\s*$/;
+
+main();
+
+function main() {
+  const date = new Date().toISOString().slice(0, 10);
+
+  const updated = fs
+    .readdirSync(PACKAGES_DIR)
+    .map((pkg) => path.join(PACKAGES_DIR, pkg, 'CHANGELOG.md'))
+    .filter((changelog) => fs.existsSync(changelog))
+    .filter((changelog) => addDate(changelog, date));
+
+  if (!updated.length) {
+    consola.info('No undated changelog headings found');
+    return;
+  }
+
+  updated.forEach((changelog) => consola.success(`Dated ${changelog}`));
+}
+
+function addDate(changelog, date) {
+  const lines = fs.readFileSync(changelog, 'utf-8').split('\n');
+  const index = lines.findIndex((line) => line.startsWith('## '));
+
+  if (index === -1 || !HEADING.test(lines[index])) {
+    return false;
+  }
+
+  lines[index] = `${lines[index].trimEnd()} (${date})`;
+  fs.writeFileSync(changelog, lines.join('\n'));
+  return true;
+}

--- a/devtools/scripts/changelog-sync.mjs
+++ b/devtools/scripts/changelog-sync.mjs
@@ -1,0 +1,57 @@
+import { consola } from 'consola';
+import * as fs from 'fs';
+
+/**
+ * Mirrors each package changelog into its counterpart under `docs/content`.
+ *
+ * The docs copies are plain duplicates, and were previously kept up to date by
+ * hand, so a release could ship with the docs site a version behind. The
+ * Release workflow runs this after dating the published entries.
+ *
+ * Packages absent from this map have no changelog page in the docs.
+ */
+const CHANGELOGS = {
+  'packages/typedoc-plugin-markdown/CHANGELOG.md':
+    'docs/content/docs/CHANGELOG.md',
+  'packages/typedoc-plugin-frontmatter/CHANGELOG.md':
+    'docs/content/plugins/frontmatter/CHANGELOG.md',
+  'packages/typedoc-plugin-remark/CHANGELOG.md':
+    'docs/content/plugins/remark/CHANGELOG.md',
+  'packages/typedoc-vitepress-theme/CHANGELOG.md':
+    'docs/content/plugins/vitepress/CHANGELOG.md',
+  'packages/docusaurus-plugin-typedoc/CHANGELOG.md':
+    'docs/content/plugins/docusaurus/changelog/docusaurus-plugin.md',
+  'packages/typedoc-docusaurus-theme/CHANGELOG.md':
+    'docs/content/plugins/docusaurus/changelog/docusaurus-theme.md',
+};
+
+main();
+
+function main() {
+  const missing = Object.entries(CHANGELOGS)
+    .flat()
+    .filter((file) => !fs.existsSync(file));
+
+  if (missing.length) {
+    consola.error(
+      `Changelog paths no longer exist, update the map in this script:\n  ${missing.join('\n  ')}`,
+    );
+    process.exit(1);
+  }
+
+  const synced = Object.entries(CHANGELOGS).filter(([source, target]) => {
+    const contents = fs.readFileSync(source, 'utf-8');
+    if (contents === fs.readFileSync(target, 'utf-8')) {
+      return false;
+    }
+    fs.writeFileSync(target, contents);
+    return true;
+  });
+
+  if (!synced.length) {
+    consola.info('Docs changelogs already in sync');
+    return;
+  }
+
+  synced.forEach(([, target]) => consola.success(`Synced ${target}`));
+}

--- a/docs/content/docs/CHANGELOG.md
+++ b/docs/content/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.12.0 (2026-06-02)
+
+### Minor Changes
+
+- Support JSDoc-style `<caption>` labels for `@example` tags ([#861](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/861)).
+- Add Markdown theme translations for the `fr` locale.
+
+### Patch Changes
+
+- Fixed duplicate sidebar groups when `navigation.includeCategories=true` and `navigation.includeGroups=false` ([#866](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/866)).
+
 ## 4.11.0 (2026-03-18)
 
 ### Minor Changes

--- a/docs/content/docs/CHANGELOG.md
+++ b/docs/content/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 4.13.0 (2026-08-25)
+
+### Minor Changes
+
+- add a parametersFormat: "none" option to completely drop the parameter list/table and its heading ([#876](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/876)) - thanks @Jym77.
+- expand type parameters in signatures when expandParameters is set ([#875](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/875)) - thanks @Jym77.
+
+### Patch Changes
+
+- fix signature parameters ([#874](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/874)) - thanks @Jym77.
+- Symbol links without a declaration reference now print a warning and render as plain text instead of attempting to resolve to the nearest link ([#870](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/870)).
+- `formatWithPrettier` now resolves Prettier config against the file being written and reads `.editorconfig`, so path-specific settings are honoured ([#881](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/881)).
+
 ## 4.12.0 (2026-06-02)
 
 ### Minor Changes

--- a/docs/content/plugins/vitepress/CHANGELOG.md
+++ b/docs/content/plugins/vitepress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.3 (2026-06-02)
+
+### Patch Changes
+
+- Skip fenced code blocks in link-encoding regex ([#862](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/862)) - thanks @Kyujenius.
+
 ## 1.1.2 (2025-01-07)
 
 ### Patch Changes

--- a/packages/typedoc-plugin-markdown/CHANGELOG.md
+++ b/packages/typedoc-plugin-markdown/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.13.0
+## 4.13.0 (2026-08-25)
 
 ### Minor Changes
 


### PR DESCRIPTION
Changesets writes `## 1.2.3` with no date, and the changelog copies under `docs/content` are hand-maintained duplicates. Both steps have been manual, and both have been missed: the 2026-06-02 release left the markdown plugin and vitepress theme docs a version behind, and 4.13.0 went out with an undated heading.

This automates both as a single post-publish step in the Release workflow.

## Why after publish, not during `changeset version`

`changeset version` runs when the release PR is *opened*, so stamping there would record the date the PR was created rather than the release. Those PRs sit for a while, so the two can differ by days.

Instead the workflow stamps once packages have actually been published, gated on the action's `published` output, and commits the result back:

```yaml
- name: Date and sync the published changelogs
  if: steps.changesets.outputs.published == 'true'
  run: |
    node ./devtools/scripts/changelog-dates.mjs
    node ./devtools/scripts/changelog-sync.mjs
    ...
    git commit -m "chore(release): date and sync changelogs [skip ci]"
    git push origin HEAD:${{ github.ref_name }}
```

Dating runs before syncing so the docs copies receive the heading with its date, not a bare version they would never catch up on. `[skip ci]` keeps that push from re-triggering the release workflow.

Two trade-offs this accepts:

- **The npm tarball will not carry the date.** Publishing happens before the stamp, so the `CHANGELOG.md` inside the published package shows `## 4.13.0` bare. The GitHub copy gets the date, and the tarball catches up on the following release.
- **CI needs push rights to `main`.** `permissions: contents: write` is already set, so this works unless branch protection blocks the `GITHUB_TOKEN`. If it does, the step fails at the push *after* a successful publish — worth watching on the first release, since it would go red on an otherwise fine run.

## The scripts

`devtools/scripts/changelog-dates.mjs` appends ` (YYYY-MM-DD)` (UTC) to the topmost `## <version>` heading of each `packages/*/CHANGELOG.md`, and only when it has no date — so it is idempotent and leaves earlier entries alone.

`devtools/scripts/changelog-sync.mjs` mirrors each package changelog into its docs counterpart. Six pairs, not the four that are obvious from a glob:

| package | docs target |
|---|---|
| typedoc-plugin-markdown | `docs/content/docs/CHANGELOG.md` |
| typedoc-plugin-frontmatter | `docs/content/plugins/frontmatter/CHANGELOG.md` |
| typedoc-plugin-remark | `docs/content/plugins/remark/CHANGELOG.md` |
| typedoc-vitepress-theme | `docs/content/plugins/vitepress/CHANGELOG.md` |
| docusaurus-plugin-typedoc | `docs/content/plugins/docusaurus/changelog/docusaurus-plugin.md` |
| typedoc-docusaurus-theme | `docs/content/plugins/docusaurus/changelog/docusaurus-theme.md` |

The docusaurus pair lives under a `changelog/` directory with renamed `.md` files, so the map is explicit rather than derived. `github-wiki` and `gitlab-wiki` have no changelog page and are deliberately absent. If a mapped path ever disappears the script exits non-zero, so a renamed docs page fails the release run instead of silently dropping a package.

## Backfill

Two commits fix the drift that already exists, and are one-offs — later releases are handled by the workflow:

- the `4.12.0` / `1.1.3` blocks the docs copies were missing
- `4.13.0`, which published earlier today before this landed, so it could not catch its own release. Dated `2026-08-25`, matching the actual publish.

## Verification

Ran against a scratch clone of the repo at `HEAD`, simulating what changesets leaves behind — an undated `## 4.13.0` entry with a stale docs copy. One pass dated the entry, propagated the dated heading to the docs, and committed exactly those two files. A second pass reported `No undated changelog headings found` / `Docs changelogs already in sync` and produced no commit. Also confirmed the missing-path guard exits 1, and that a deliberately reverted docs copy is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)