### PR TITLE
docs(quality): add branch naming convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,24 @@ Changes touching only a package's `README.md`, `CHANGELOG.md`, or
 CI runs on **Node 18 and 20** (engines: `>= 18`). Local dev is often on a newer
 Node — do not use APIs newer than Node 18 in package source.
 
+## Branch names
+
+Branch off `main`, named after the issue being addressed:
+
+- `fix/<issue>-<slug>` — bug fixes
+- `feature/<issue>-<slug>` — enhancements, new options, new theme resources
+
+`<issue>` is the GitHub issue number; `<slug>` is two to four kebab-case
+words. Examples: `fix/881-prettier-editorconfig`,
+`feature/873-expose-lib-functions`.
+
+Use the issue number whenever one exists — including for preparatory or
+follow-up commits that only lead up to the main change, so the whole thread
+of work stays greppable against the issue.
+
+For work with no issue behind it (repo tooling, docs prose, dependency bumps,
+release chores) drop the number and use `chore/<slug>`.
+
 ## Commit messages
 
 Commitlint runs on a husky `commit-msg` hook and **rejects non-conforming
@@ -163,3 +181,4 @@ entry tells users nothing they can act on.
 - [ ] Snapshot changes, if any, reviewed in the git diff and intentional
 - [ ] Changeset added for user-facing changes
 - [ ] Commit messages pass commitlint (type + scope from the enums above)
+- [ ] Branch name follows `fix/<issue>-<slug>` / `feature/<issue>-<slug>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,11 @@ provided internal docs.
 
 ## Submitting a PR
 
+Name your branch after the issue it addresses - `fix/<issue>-<slug>` for bug
+fixes, `feature/<issue>-<slug>` for enhancements (for example
+`fix/881-prettier-editorconfig`). If there is no associated issue, use
+`chore/<slug>`.
+
 Once you're ready to submit your changes:
 
 * **Push your branch**: Push your branch to your forked repository on GitHub.


### PR DESCRIPTION
Documents a branch naming convention, which until now was implicit — existing branches range from `fix/881-prettier-editorconfig` to `npm-keywords` to `refactor-wip`.

| Kind | Pattern |
| --- | --- |
| Bug fixes | `fix/<issue>-<slug>` |
| Enhancements, new options, theme resources | `feature/<issue>-<slug>` |
| No associated issue (tooling, docs prose, deps, release) | `chore/<slug>` |

`<slug>` is two to four kebab-case words. The `fix/` form matches what's already in use.

### Changes

- **AGENTS.md** — new `## Branch names` section, placed before `## Commit messages` so the file reads branch → commit → changeset → PR. Added to the pre-PR checklist.
- **CONTRIBUTING.md** — short note under *Submitting a PR*. No Contents change needed.

### Notes

- The rule says to use the issue number **whenever one exists**, including for preparatory and follow-up commits. The two patterns alone don't cover prep work, and leaving it implicit would let the setup commits for an issue drift out of the greppable set.
- A stale local branch named exactly `chore` blocked the `chore/` prefix — git can't hold both a ref and a directory at that path. It was fully merged into `main` with no remote counterpart, and was deleted locally. Nothing was pushed or rewritten.

Docs only — no changeset, and no package CI is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)