### PR TITLE
docs(quality): correct custom theme examples

### DIFF
--- a/packages/typedoc-plugin-markdown/internal-docs/custom-theme.md
+++ b/packages/typedoc-plugin-markdown/internal-docs/custom-theme.md
@@ -27,7 +27,7 @@ The theme can then be consumed by the `theme` option:
 
 ```json filename="typedoc.json"
 {
-  "plugin": ["typedoc-plugin-mardown", "./local-plugins/my-custom-plugin.js"],
+  "plugin": ["typedoc-plugin-markdown", "./local-plugins/my-custom-plugin.js"],
   "theme": "customTheme"
 }
 ```
@@ -43,30 +43,36 @@ class MyMarkdownTheme extends MarkdownTheme {
 
 class MyMarkdownThemeContext extends MarkdownThemeContext {
   // customise templates
-  templates = {
-    ...this.templates,
-    reflection: (model) => {
-      return `New template for ${model.name}!`;
+  templates: MarkdownThemeContext['templates'] = {
+    ...(this as MarkdownThemeContext).templates,
+    reflection: (page) => {
+      return `New template for ${page.model.name}!`;
     },
   };
 
   // customise partials
-  partials = {
-    ...this.partials,
-    header: (model) => {
+  partials: MarkdownThemeContext['partials'] = {
+    ...(this as MarkdownThemeContext).partials,
+    header: () => {
       return `
-# Welcome to custom header for ${this.page.project.name} project and ${model.name} model!
+# Welcome to custom header for ${this.page.project.name} project!
 Use my new helper - ${this.helpers.newHelper()}
-   `;
+`;
     },
   };
 
   // customise helpers
   helpers = {
-    ...this.helpers,
+    ...(this as MarkdownThemeContext).helpers,
     newHelper: () => {
       return 'New helper!';
     },
   };
 }
 ```
+
+Note the shape of the overrides:
+
+- Spread via `(this as MarkdownThemeContext)` rather than plain `this`. The base class has already initialized these fields by the time the subclass initializers run, but TypeScript sees the subclass declaration as self-referential and reports `TS2729` without the cast.
+- Annotating `templates` and `partials` gives each override's params their types from the base, so they do not need annotating individually. Leave `helpers` unannotated where the intention is to add new helpers to it.
+- Each resource takes the params of the one it replaces. `templates.reflection` receives the page event (`page.model` is the reflection), while `partials.header` takes none and reads `this.page`.


### PR DESCRIPTION
Started as "make `partials = { ...this.partials }` typecheck", but the cast alone doesn't work — the example's overrides have the wrong signatures, which is what makes the types incompatible. Both were verified against the built package.

### The example was broken at runtime

| | Documented | Actual signature | Result |
| --- | --- | --- | --- |
| `partials.header` | `(model) => …${model.name}` | takes **no** params | `TypeError: Cannot read properties of undefined (reading 'name')` |
| `templates.reflection` | `(model) => …${model.name}` | receives the `MarkdownPageEvent` | renders `New template for undefined!` |

Anyone copying the header example got a crash.

### And it didn't typecheck

Spreading plain `this.partials` in a subclass field gives `TS2729: Property 'partials' is used before its initialization`. It works at runtime — the base class initializers have already run by then — but TypeScript sees the subclass declaration as self-referential. `super.partials` is not an alternative (`TS2855`: parent class fields aren't reachable via `super`).

### Fix

- Correct both signatures — `header: ()` reading `this.page`, `reflection: (page)` using `page.model.name`.
- Spread via `(this as MarkdownThemeContext)`.
- Annotate `templates` and `partials` so overrides get param types contextually from the base; leave `helpers` unannotated so new helpers can be added to it.
- Add a note explaining all three points, since none is obvious.
- Fix a `typedoc-plugin-mardown` typo in the adjacent config sample.

### Verified

- Typechecks clean under `strict` (previously 9 errors).
- Runs: header renders the project name, reflection renders the model name, and all 62 partials / 19 helpers survive the spread.

Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)