### PR TITLE
docs(quality): document issue linking convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,27 @@ of work stays greppable against the issue.
 For work with no issue behind it (repo tooling, docs prose, dependency bumps,
 release chores) drop the number and use `chore/<slug>`.
 
+## Linking issues
+
+Reference issues without a closing keyword — `Refs #873`, or a bare `(#873)`
+at the end of a commit subject:
+
+```
+fix(core): resolve anchors for inherited members (#900)
+```
+
+**Never write `Closes #873`, `Fixes #873` or `Resolves #873`** in a commit
+message or a PR description. Issues here are closed when the fix is published
+to npm, not when the PR merges, and GitHub has no repository setting to turn
+that behaviour off — the keyword is the only trigger, so avoiding it is the
+only control.
+
+GitHub acts on `close`/`closes`/`closed`, `fix`/`fixes`/`fixed` and
+`resolve`/`resolves`/`resolved` when immediately followed by an issue
+reference, in a PR description or in any commit merged to `main`. The commit
+convention above is safe because the keyword is never adjacent to the number —
+`fix(core): … (#900)` does not trigger it, but `fix #900` would.
+
 ## Commit messages
 
 Commitlint runs on a husky `commit-msg` hook and **rejects non-conforming
@@ -182,3 +203,4 @@ entry tells users nothing they can act on.
 - [ ] Changeset added for user-facing changes
 - [ ] Commit messages pass commitlint (type + scope from the enums above)
 - [ ] Branch name follows `fix/<issue>-<slug>` / `feature/<issue>-<slug>`
+- [ ] No closing keywords (`Closes`/`Fixes`/`Resolves`) in commits or the PR description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Once you're ready to submit your changes:
 * **Push your branch**: Push your branch to your forked repository on GitHub.
 * **Create a PR**: Navigate to the original repository and create a PR from your branch to the main branch.
 * **Provide a clear description**: Include a detailed description of your changes, why they're necessary, and any issues they resolve.
-* **Link to relevant issues**: If your PR addresses any open issues, mention them in the description.
+* **Link to relevant issues**: If your PR addresses any open issues, mention them in the description - as `Refs #123` rather than `Closes #123`. Issues are closed once the change is published to npm, so please avoid the `Closes`/`Fixes`/`Resolves` keywords that make GitHub close them on merge.
 
 Please note we follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages.
 


### PR DESCRIPTION
Issues in this repo are closed when a change is **published to npm**, not when the PR merges. GitHub's closing keywords break that, and there is no repository setting to disable them — the keyword is the only trigger, so avoiding it is the only control.

### The rule

Reference issues as `Refs #873`, or a bare `(#873)` at the end of a commit subject. Never `Closes` / `Fixes` / `Resolves` followed by a reference, in a commit message or a PR description.

### Worth knowing

The existing commit convention is already safe by construction — GitHub only acts when the keyword is *immediately followed* by the reference:

- `fix(core): resolve anchors for inherited members (#900)` — no close
- `fix #900` — closes

So the real exposure is PR descriptions, which is where this actually came up: #888 was opened with `Closes #873` and has since been corrected to `Refs #873`.

### Changes

- **AGENTS.md** — new `## Linking issues` section before `## Commit messages`, plus a pre-PR checklist item.
- **CONTRIBUTING.md** — extends the existing *Link to relevant issues* bullet rather than adding a new section.

Both state the reason, not just the rule — otherwise the next contributor adds `Closes #x` as a courtesy.

Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)