### PR TITLE
fix(all): declare typedoc as a peer dependency (#891)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,14 +13,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": [
-    "@devtools/*",
-    "typedoc-github-wiki-theme",
-    "typedoc-gitlab-wiki-theme",
-    "typedoc-plugin-remark",
-    "typedoc-docusaurus-theme",
-    "typedoc-vitepress-theme",
-    "docusaurus-plugin-typedoc",
-    "typedoc-plugin-frontmatter"
-  ]
+  "ignore": ["@devtools/*"]
 }

--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,11 @@
+---
+'typedoc-plugin-frontmatter': patch
+'typedoc-plugin-remark': patch
+'typedoc-vitepress-theme': patch
+'typedoc-docusaurus-theme': patch
+'docusaurus-plugin-typedoc': patch
+'typedoc-github-wiki-theme': patch
+'typedoc-gitlab-wiki-theme': patch
+---
+
+- Declare `typedoc` as a peer dependency so it resolves from the package's own `node_modules` rather than the consumer's hoisting layout (#891).

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2766,7 +2765,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2790,7 +2788,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2905,7 +2902,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3343,7 +3339,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5749,7 +5744,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -5784,7 +5778,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5925,7 +5918,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -6384,7 +6376,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6457,7 +6448,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6998,7 +6988,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8063,7 +8052,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8256,7 +8244,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9275,7 +9262,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -10052,7 +10038,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14302,7 +14287,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15018,7 +15002,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16007,7 +15990,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16593,7 +16575,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17002,7 +16983,6 @@
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -17033,7 +17013,6 @@
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17820,7 +17799,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -19029,7 +19009,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19428,7 +19407,6 @@
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -19516,7 +19494,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19947,7 +19924,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20177,7 +20153,6 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20799,7 +20774,11 @@
       "devDependencies": {
         "@docusaurus/core": "3.8.1"
       },
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     },
@@ -21394,21 +21373,33 @@
     "packages/typedoc-docusaurus-theme": {
       "version": "1.4.2",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     },
     "packages/typedoc-github-wiki-theme": {
       "version": "2.1.0",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     },
     "packages/typedoc-gitlab-wiki-theme": {
       "version": "2.1.0",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     },
@@ -21418,14 +21409,17 @@
       "dependencies": {
         "yaml": "^2.8.1"
       },
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     },
     "packages/typedoc-plugin-markdown": {
-      "version": "4.11.0",
+      "version": "4.13.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -21441,14 +21435,22 @@
         "remark-frontmatter": "^5.0.0",
         "vfile": "^6.0.3"
       },
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     },
     "packages/typedoc-vitepress-theme": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
+        "typedoc": "0.28.x",
         "typedoc-plugin-markdown": ">=4.11.0"
       }
     }

--- a/packages/docusaurus-plugin-typedoc/package.json
+++ b/packages/docusaurus-plugin-typedoc/package.json
@@ -30,6 +30,7 @@
   "author": "Thomas Grey",
   "license": "MIT",
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "dependencies": {

--- a/packages/typedoc-docusaurus-theme/package.json
+++ b/packages/typedoc-docusaurus-theme/package.json
@@ -30,6 +30,7 @@
     "test:update": "npm run build && rm -rf ./test/__snapshots__ && npm test"
   },
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "license": "MIT",

--- a/packages/typedoc-github-wiki-theme/package.json
+++ b/packages/typedoc-github-wiki-theme/package.json
@@ -31,6 +31,7 @@
   "author": "Thomas Grey",
   "license": "MIT",
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "engines": {

--- a/packages/typedoc-gitlab-wiki-theme/package.json
+++ b/packages/typedoc-gitlab-wiki-theme/package.json
@@ -31,6 +31,7 @@
   "author": "Thomas Grey",
   "license": "MIT",
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "engines": {

--- a/packages/typedoc-plugin-frontmatter/package.json
+++ b/packages/typedoc-plugin-frontmatter/package.json
@@ -34,6 +34,7 @@
     "yaml": "^2.8.1"
   },
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "engines": {

--- a/packages/typedoc-plugin-remark/package.json
+++ b/packages/typedoc-plugin-remark/package.json
@@ -33,6 +33,7 @@
     "vfile": "^6.0.3"
   },
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "engines": {

--- a/packages/typedoc-vitepress-theme/package.json
+++ b/packages/typedoc-vitepress-theme/package.json
@@ -30,6 +30,7 @@
     "test:update": "npm run build && rm -rf ./test/__snapshots__ && npm test"
   },
   "peerDependencies": {
+    "typedoc": "0.28.x",
     "typedoc-plugin-markdown": ">=4.11.0"
   },
   "license": "MIT",


### PR DESCRIPTION
Refs #891

## Problem

Every non-core package emits a runtime `import ... from 'typedoc'` in its built output, but none declared a dependency on `typedoc` — not in `dependencies`, not in `peerDependencies`:

| Package | Runtime `typedoc` import in `dist` |
| --- | --- |
| `typedoc-plugin-frontmatter` | `comments.js`, `options/declarations.js` |
| `typedoc-plugin-remark` | `helpers.js`, `options/constants.js`, `options/declarations.js` |
| `typedoc-vitepress-theme` | `options/declarations.js` |
| `typedoc-docusaurus-theme` | `options/declarations.js` |
| `typedoc-github-wiki-theme` | `options/declarations.js` |
| `typedoc-gitlab-wiki-theme` | `options/declarations.js` |
| `docusaurus-plugin-typedoc` | type-only (`.d.ts`), needed for consumer type resolution |

`ReflectionKind` and `ParameterType` are enums, so these are value imports that survive compilation — not erasable type-only imports.

A peer dependency on `typedoc-plugin-markdown` does not supply `typedoc`. Peers are not transitive providers, and Node resolves by walking parent directories from the importing file — it never routes through another package to reach what that package can see. Resolution therefore fell through to whatever the consumer's hoisting layout happened to leave at the root, which is environment-dependent rather than deterministic. Under package managers that do not flatten `node_modules`, the plugin fails to load entirely.

This has gone unnoticed because a flat `node_modules` (npm, yarn classic) puts a real `typedoc` link at the root, so the walk succeeds — by hoisting, not by declaration.

Separately, nothing currently checks *which* `typedoc` gets picked up. npm validates the core plugin's `0.28.x` peer, but these packages had no declared constraint and would silently bind to any version found.

## Change

- Declare `"typedoc": "0.28.x"` in `peerDependencies` across all seven packages, mirroring `typedoc-plugin-markdown`.
- Reduce the changesets `ignore` list to `["@devtools/*"]` so the fix can actually be released — this follows the existing per-release pattern (see c66f7696, which did the same for `typedoc-plugin-frontmatter`). `docusaurus-plugin-typedoc` and `typedoc-docusaurus-theme` are `fixed` together, so both must come out regardless.
- Add a changeset covering all seven at `patch`.

## Verification

- `npm ls typedoc` now shows a satisfied `typedoc` edge under all seven packages, where previously only `typedoc-plugin-markdown` had one.
- `npx changeset status` lists exactly those seven at patch — core untouched, no mixed-changeset error.
- `npm run lint --workspaces --if-present` clean.

Not built/tested beyond lint: the diff is manifest-only and `typedoc` still dedupes to the same `0.28.19` in the tree, so nothing the build observes changed. Each package's `prepublishOnly` runs lint + build + test at publish time regardless.

## Notes for review

- **CI will not run.** Every workflow path filter excludes `packages/*/package.json`, and this PR touches only manifests, the lockfile and the changeset.
- **The `package-lock.json` diff is larger than this change.** `npm install` reconciled pre-existing drift: `typedoc-vitepress-theme` was recorded as `1.1.2` (it is `1.1.3` on npm), missing `engines` blocks were backfilled, and some `"peer": true` flags on dev dependencies were normalised away. None of that originates here.
- The ignore entries should be restored in a follow-up chore once the release lands, per the 2dccc7f9 precedent.