### PR TITLE
docs(quality): adopt Assisted-by trailer for AI-assisted commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,29 @@ Use `core` for `typedoc-plugin-markdown`. Example:
 `fix(core): resolve anchors for inherited members (#900)`.
 `feat: add option` fails (empty scope).
 
+### AI attribution
+
+Work done with an AI coding agent is marked with a single trailer:
+
+```
+Assisted-by: Claude Code
+```
+
+No email address — the trailer names a tool, not a person.
+
+**Never use `Co-Authored-By` for an AI tool.** That trailer asserts
+co-authorship: git and GitHub treat it as a second author and surface it as a
+contributor. Authorship carries accountability — answering a bug report,
+standing behind the change, being bound by the licence — and a model does none
+of those. The human who reviews the change and pushes it is its sole author.
+`Assisted-by:` is the convention converging across open source for tool-assisted
+work; `Generated-by:` is its counterpart where a substantial portion is machine
+written.
+
+Do not add "Generated with …" footers to PR descriptions. This file is the
+project's disclosure that AI agents work here, and it says so more usefully than
+a per-commit marker.
+
 ## Changesets
 
 User-facing changes to a published package need a changeset in `.changeset/`
@@ -268,3 +291,4 @@ latest release stayed on the same TypeDoc line.
 - [ ] Commit messages pass commitlint (type + scope from the enums above)
 - [ ] Branch name follows `fix/<issue>-<slug>` / `feature/<issue>-<slug>`
 - [ ] No closing keywords (`Closes`/`Fixes`/`Resolves`) in commits or the PR description
+- [ ] AI-assisted commits use `Assisted-by: Claude Code`, never `Co-Authored-By`


### PR DESCRIPTION
Records a convention for marking AI-assisted work in `AGENTS.md`, replacing the `Co-Authored-By` trailer that had been applied inconsistently (9 of 2582 commits on `main`, all within a two-day window).

## Why published history isn't being rewritten

Tidying the existing trailers would mean rebasing 10 commits on `main`. `typedoc-plugin-markdown@4.13.0` carries an npm provenance attestation signed against source commit `57302a9f`, which sits inside that range:

```
source commit: 57302a9f440cafccac04f18ec11def2f74f7478b
workflow:      .github/workflows/release.yml @ refs/heads/main
```

Rewriting past it leaves the signed attestation pointing at a SHA that no longer exists in the repo, and moves the `typedoc-plugin-markdown@4.13.0` tag off its commit. That is a supply-chain integrity regression in exchange for cosmetic cleanup, so the convention applies going forward only.

This reasoning is recorded here rather than in `AGENTS.md`: it explains a decision taken once, not a rule contributors need to carry.
