### PR TITLE
fix(release): stop prepublishOnly rebuilding during concurrent publish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,21 @@ are read from `package.json` at publish time, so they ship with the next
 release regardless — a changeset for them only cuts a version whose changelog
 entry tells users nothing they can act on.
 
+## Releasing
+
+`npm run release` is the only supported publish path. Its `prerelease` hook runs
+`build-all` across the workspaces in dependency order, so every `dist` is
+freshly built before `changeset publish` starts.
+
+**`prepublishOnly` must not run `npm run build`.** Changesets publishes every
+package *concurrently*, and each `prebuild` begins with `rm -rf dist`. Because
+`docusaurus-plugin-typedoc` depends on `typedoc-docusaurus-theme` and imports
+from it, a concurrent rebuild deletes the `dist` it is compiling against, and
+`tsc` fails with `TS2307: Cannot find module` and exit code 2. That is what
+broke the 1.4.3 release, leaving six of seven packages published. The
+`prerelease` build has already done the work — re-doing it per package adds
+nothing but the race.
+
 ## Docs site
 
 - Prose lives in `docs/content` (MDX); edit freely.

--- a/packages/docusaurus-plugin-typedoc/package.json
+++ b/packages/docusaurus-plugin-typedoc/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint": "eslint ./src",
     "prebuild": "rm -rf dist && copyfiles --up 1 ./src/**/*.cjs ./dist/",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint",
     "build": "tsc",
     "pretest": "rm -rf ./test/out && NO_UPDATE_NOTIFIER=1 docusaurus generate-typedoc",
     "test": "mocha --config ./mocha.config.json",

--- a/packages/typedoc-docusaurus-theme/package.json
+++ b/packages/typedoc-docusaurus-theme/package.json
@@ -21,7 +21,7 @@
   "author": "Thomas Grey",
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint",
     "prebuild": "rm -rf dist && prebuild-options",
     "build": "tsc",
     "build-and-run": "npm run build && npm run pretest",

--- a/packages/typedoc-github-wiki-theme/package.json
+++ b/packages/typedoc-github-wiki-theme/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://typedoc-plugin-markdown.org/plugins/github-wiki",
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint",
     "prebuild": "rm -rf dist && prebuild-options",
     "build": "tsc",
     "build-and-test": "npm run build && npm run test",

--- a/packages/typedoc-gitlab-wiki-theme/package.json
+++ b/packages/typedoc-gitlab-wiki-theme/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://typedoc-plugin-markdown.org/plugins/gitlab-wiki",
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint",
     "prebuild": "rm -rf dist && prebuild-options",
     "build": "tsc",
     "build-and-test": "npm run build && npm run test",

--- a/packages/typedoc-plugin-frontmatter/package.json
+++ b/packages/typedoc-plugin-frontmatter/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build && npm run test",
+    "prepublishOnly": "npm run lint && npm run test",
     "prebuild": "rm -rf dist && prebuild-options",
     "build": "tsc",
     "build-and-test": "npm run build && npm run test",

--- a/packages/typedoc-plugin-markdown/package.json
+++ b/packages/typedoc-plugin-markdown/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build && npm run schema",
+    "prepublishOnly": "npm run lint && npm run schema",
     "prebuild": "rm -rf dist && prebuild-options && tsx ./scripts/prebuild",
     "build": "tsc && tsc-alias",
     "build-and-run": "npm run build && npm run fixtures -- -isDEV",

--- a/packages/typedoc-plugin-remark/package.json
+++ b/packages/typedoc-plugin-remark/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint",
     "prebuild": "rm -rf dist && prebuild-options",
     "build": "tsc",
     "build-and-run": "npm run build && npm run pretest",

--- a/packages/typedoc-vitepress-theme/package.json
+++ b/packages/typedoc-vitepress-theme/package.json
@@ -21,7 +21,7 @@
   "author": "Thomas Grey",
   "scripts": {
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint",
     "prebuild": "rm -rf dist && prebuild-options",
     "build": "tsc",
     "build-and-test": "npm run build && npm run test",


### PR DESCRIPTION
Fixes the race that broke the 1.4.3 release, where six of seven packages published and `docusaurus-plugin-typedoc` failed.

## What happened

`changeset publish` publishes every package **concurrently** — in [run 34153535921](https://github.com/typedoc2md/typedoc-plugin-markdown/actions/runs/34153535921) all seven `Publishing` lines are stamped `18:56:01.00`. Each package's `prepublishOnly` ran `npm run lint && npm run build`, and every `prebuild` begins with `rm -rf dist`.

`docusaurus-plugin-typedoc` is the only package with an intra-workspace runtime dependency:

```json
"dependencies": { "typedoc-docusaurus-theme": "^1.4.3" }
```

and its source imports from it. So `typedoc-docusaurus-theme` deleted its own `dist` while `docusaurus-plugin-typedoc`'s `tsc` was resolving types from it:

```
error TS2307: Cannot find module … or its corresponding type declarations.
npm error code 2
```

That is the only package pair in the repo shaped this way, which is why exactly one package failed. It had not bitten before because both are normally in the changesets `ignore` list and had never published alongside six siblings at once.

## The fix

The `prerelease` hook already runs `build-all` across the workspaces in dependency order before `changeset publish` starts, so every `dist` is freshly built by the time publishing begins. The per-package rebuild was pure redundancy — and the only thing introducing the race.

`npm run build` is dropped from `prepublishOnly` in all eight packages. The `lint`, `test` and `schema` gates stay, and none of them mutate `dist`.

## Verification

- `npm run build-all` clean; all eight `dist` directories populated.
- `npm run prepublishOnly` passes for `docusaurus-plugin-typedoc`, `typedoc-docusaurus-theme` and `typedoc-plugin-markdown`, and leaves `dist` intact (8 / 8 / 12 files before and after) — previously it emptied and rebuilt it.
- `npm run lint --workspaces --if-present` clean.

No changeset: `scripts` entries are inert for consumers, so the installed packages are unchanged.

## Not addressed here

Two separate problems surfaced while diagnosing this, both worth their own change:

1. **The release job cannot push its changelog commit.** `Date and sync the published changelogs` commits to `main` and pushes directly, which branch protection rejects with `GH006: Protected branch update failed … Changes must be made through a pull request`. The dates and the `docs/content` sync are generated on the runner and then discarded, so they are currently missing for the 1.4.3 release.
2. **`entryModule`'s help text is truncated in the generated schema.** `declarations.ts` has `'@deprecated This functionality has been deprecated in favour of the @mergeModuleWith tag.'` — the generator truncates at the second `@` tag, yielding "in favour of the". The committed `docs/public/schema.json` still holds the correct text because it has not been regenerated since 2026-07-21; the backticks that used to protect `@mergeModuleWith` were removed from the declaration afterwards.
