### PR TITLE
chore(release): date and sync the changelogs for the 2026-09-07 release

### DIFF
--- a/docs/content/plugins/docusaurus/changelog/docusaurus-plugin.md
+++ b/docs/content/plugins/docusaurus/changelog/docusaurus-plugin.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.3 (2026-09-07)
+
+### Patch Changes
+
+- Declare `typedoc` as a peer dependency so it resolves from the package's own `node_modules` rather than the consumer's hoisting layout ([#891](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/891)).
+- Updated peer dependencies
+  - typedoc-docusaurus-theme@1.4.3
+
 ## 1.4.2 (2025-08-04)
 
 ### Patch Changes

--- a/docs/content/plugins/docusaurus/changelog/docusaurus-theme.md
+++ b/docs/content/plugins/docusaurus/changelog/docusaurus-theme.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3 (2026-09-07)
+
+### Patch Changes
+
+- Declare `typedoc` as a peer dependency so it resolves from the package's own `node_modules` rather than the consumer's hoisting layout ([#891](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/891)).
+
 ## 1.4.2 (2025-08-04)
 
 - Bump docusaurus-plugin-typedoc to 1.4.2

--- a/docs/content/plugins/frontmatter/CHANGELOG.md
+++ b/docs/content/plugins/frontmatter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.2 (2026-09-07)
+
+### Patch Changes
+
+- Declare `typedoc` as a peer dependency so it resolves from the package's own `node_modules` rather than the consumer's hoisting layout ([#891](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/891)).
+
 ## 1.3.1 (2025-11-23)
 
 ### Patch Changes

--- a/docs/content/plugins/remark/CHANGELOG.md
+++ b/docs/content/plugins/remark/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2 (2026-09-07)
+
+### Patch Changes
+
+- Declare `typedoc` as a peer dependency so it resolves from the package's own `node_modules` rather than the consumer's hoisting layout ([#891](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/891)).
+
 ## 2.0.1 (2025-06-01)
 
 ### Patch Changes

--- a/docs/content/plugins/vitepress/CHANGELOG.md
+++ b/docs/content/plugins/vitepress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.4 (2026-09-07)
+
+### Patch Changes
+
+- Declare `typedoc` as a peer dependency so it resolves from the package's own `node_modules` rather than the consumer's hoisting layout ([#891](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/891)).
+
 ## 1.1.3 (2026-06-02)
 
 ### Patch Changes

--- a/packages/docusaurus-plugin-typedoc/CHANGELOG.md
+++ b/packages/docusaurus-plugin-typedoc/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.3
+## 1.4.3 (2026-09-07)
 
 ### Patch Changes
 

--- a/packages/typedoc-docusaurus-theme/CHANGELOG.md
+++ b/packages/typedoc-docusaurus-theme/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.3
+## 1.4.3 (2026-09-07)
 
 ### Patch Changes
 

--- a/packages/typedoc-github-wiki-theme/CHANGELOG.md
+++ b/packages/typedoc-github-wiki-theme/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.1
+## 2.1.1 (2026-09-07)
 
 ### Patch Changes
 

--- a/packages/typedoc-gitlab-wiki-theme/CHANGELOG.md
+++ b/packages/typedoc-gitlab-wiki-theme/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.1
+## 2.1.1 (2026-09-07)
 
 ### Patch Changes
 

--- a/packages/typedoc-plugin-frontmatter/CHANGELOG.md
+++ b/packages/typedoc-plugin-frontmatter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.2
+## 1.3.2 (2026-09-07)
 
 ### Patch Changes
 

--- a/packages/typedoc-plugin-remark/CHANGELOG.md
+++ b/packages/typedoc-plugin-remark/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.2
+## 2.0.2 (2026-09-07)
 
 ### Patch Changes
 

--- a/packages/typedoc-vitepress-theme/CHANGELOG.md
+++ b/packages/typedoc-vitepress-theme/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.4
+## 1.1.4 (2026-09-07)
 
 ### Patch Changes
 


### PR DESCRIPTION
Restores the changelog dates and `docs/content` sync for the seven packages published on 2026-09-07.

## Why they are missing

`release.yml`'s `Date and sync the published changelogs` step ran correctly in [run 34153535921](https://github.com/typedoc2md/typedoc-plugin-markdown/actions/runs/34153535921) — it dated all seven changelogs, synced the five docs pages, and committed the result. Then the push was refused:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

The commit only ever existed on the runner, so the entries landed on `main` undated.

## This change

Produced by running the same two scripts the workflow runs:

```bash
node ./devtools/scripts/changelog-dates.mjs
node ./devtools/scripts/changelog-sync.mjs
```

The result is identical to what the workflow built — 12 files, 39 insertions, 7 deletions, matching the discarded runner commit exactly.

Both scripts are idempotent by design: `changelog-dates.mjs` considers only the topmost heading and only when it carries no date, so earlier entries are untouched and re-running is safe.

The underlying workflow problem is not addressed here — it will recur on the next release that publishes. That is handled separately.
