### PR TITLE
chore(release): open a pull request for the changelog dates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,12 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Date and sync the published changelogs
+      - name: Open a pull request dating the published changelogs
         if: steps.changesets.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/release-changelog-dates
+          BASE: ${{ github.ref_name }}
         run: |
           node ./devtools/scripts/changelog-dates.mjs
           node ./devtools/scripts/changelog-sync.mjs
@@ -42,5 +46,13 @@ jobs:
             echo "No changelog updates to commit"
             exit 0
           fi
-          git commit -m "chore(release): date and sync changelogs [skip ci]"
-          git push origin HEAD:${{ github.ref_name }}
+          git checkout -b "$BRANCH"
+          git commit -m "chore(release): date and sync changelogs"
+          git push --force origin "$BRANCH"
+          if [ "$(gh pr view "$BRANCH" --json state --jq .state 2>/dev/null)" = "OPEN" ]; then
+            echo "Updated the open changelog pull request"
+          else
+            gh pr create --base "$BASE" --head "$BRANCH" \
+              --title "chore(release): date and sync changelogs" \
+              --body "Adds release dates to the version headings Changesets wrote, and syncs them into \`docs/content\`. Opened by the Release workflow once packages were published. Merge to land the dates."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,15 @@ broke the 1.4.3 release, leaving six of seven packages published. The
 `prerelease` build has already done the work — re-doing it per package adds
 nothing but the race.
 
+**The changelog dates arrive as a pull request — merge it or they never land.**
+Changesets writes version headings without dates; after publishing, the Release
+workflow adds them and syncs `docs/content`, commits to
+`chore/release-changelog-dates` and opens a PR. It cannot push to `main`
+directly — branch protection rejects that with `GH006`, which silently cost the
+2026-09-07 release its dates. The branch is force-pushed from the current `main`
+each time and both scripts only touch undated headings, so an unmerged PR
+accumulates the next release's dates rather than conflicting.
+
 ## Docs site
 
 - Prose lives in `docs/content` (MDX); edit freely.


### PR DESCRIPTION
Stops the release workflow pushing to `main`, which branch protection refuses.

## The problem

`Date and sync the published changelogs` did its work correctly and then lost it:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

This is silent in the worst way. The publish had already succeeded, so the packages were live on npm; the job simply turned red afterwards, and the changelog entries for the seven packages released on 2026-09-07 stayed undated. It recurs on every release that publishes.

## Why a pull request rather than a bypass

The alternative is adding `github-actions` to `bypass_pull_request_allowances`. That is one setting and no new machinery, but it is not scoped to this step — it grants **every** workflow in the repository the ability to push to `main` with `GITHUB_TOKEN`, permanently. `release.yml` pins its actions to mutable major tags (`actions/checkout@v6`, `actions/setup-node@v6`, `changesets/action@v1`), so the code holding that power can change without a commit here.

`main` is also the trust root for npm provenance: every attestation this repo publishes asserts that a tarball was built from a specific commit on that branch. Keeping "everything reaches `main` through review" true is what gives those attestations meaning.

## The change

The step commits to `chore/release-changelog-dates` and opens a PR against `main`. If a PR from that branch is already open it is updated instead of duplicated.

The branch is force-pushed from the current `main` each release, and `changelog-dates.mjs` only touches the topmost heading and only when it has no date — so an unmerged PR accumulates the following release's dates rather than conflicting.

`AGENTS.md` gains a note under `## Releasing`, because the failure mode has now inverted: the dates no longer vanish silently, they wait in a PR that somebody has to merge.

## Verification

- Workflow YAML parses; the five steps resolve in order with the expected `env` block.
- The step's shell body passes `bash -n`.
- The commit message the step writes (`chore(release): date and sync changelogs`) satisfies commitlint, which runs on the runner via the husky hook installed by `npm ci`.

Not exercised end to end — that only happens on the next release that publishes. The missing 2026-09-07 dates are restored separately in #896.
