### PR TITLE
fix(core): stop JSDoc truncating the entryModule deprecation notice

### DIFF
--- a/.changeset/olive-schemas-deprecate.md
+++ b/.changeset/olive-schemas-deprecate.md
@@ -1,0 +1,5 @@
+---
+'typedoc-plugin-markdown': patch
+---
+
+- Fix truncated option descriptions in the published JSON schema and type declarations.

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -74,7 +74,7 @@
         },
         "expandParameters": {
           "type": "boolean",
-          "description": "[typedoc-plugin-markdown] Expand parameters in signature parentheses to display type information."
+          "description": "[typedoc-plugin-markdown] Expand parameters and type parameters inside signatures."
         },
         "fileExtension": {
           "type": "string",

--- a/packages/typedoc-plugin-markdown/src/options/declarations.ts
+++ b/packages/typedoc-plugin-markdown/src/options/declarations.ts
@@ -205,7 +205,7 @@ export const excludeScopesInPaths: Partial<DeclarationOption> = {
  * @category File
  */
 export const entryModule: Partial<DeclarationOption> = {
-  help: '@deprecated This functionality has been deprecated in favour of the @mergeModuleWith tag.',
+  help: '@deprecated This functionality has been deprecated in favour of the `@mergeModuleWith` tag.',
   type: ParameterType.String,
 };
 

--- a/packages/typedoc-plugin-markdown/src/types/options.ts
+++ b/packages/typedoc-plugin-markdown/src/types/options.ts
@@ -32,7 +32,7 @@ export interface PluginOptions {
   entryFileName?: string;
 
   /**
-   * @deprecated This functionality has been deprecated in favour of the @mergeModuleWith tag.
+   * @deprecated This functionality has been deprecated in favour of the `@mergeModuleWith` tag.
    */
   entryModule?: string;
 


### PR DESCRIPTION
An option's deprecation notice is cut off in the JSON schema and type declarations that ship to npm.

## What users see

`entryModule`'s help text ends mid-sentence, in `typedoc-plugin-markdown@4.13.0` as published today:

```json
"deprecated": "This functionality has been deprecated in favour of the",
"description": "[typedoc-plugin-markdown] This functionality has been deprecated in favour of the"
```

The sentence should name the replacement — `` `@mergeModuleWith` `` — which is the only useful part of a deprecation notice.

## Cause

`declarations.ts` held:

```ts
help: '@deprecated This functionality has been deprecated in favour of the @mergeModuleWith tag.',
```

That string is copied verbatim into the JSDoc comment on the generated `src/types/options.ts`, where `ts-json-schema-generator` reads `@mergeModuleWith` as the start of a **new JSDoc tag** and ends the `@deprecated` value at the word before it.

Backticking the tag stops JSDoc treating it as a tag. Every `declarations.ts` in the repo was checked for the same pattern — this is the only occurrence.

## Why this ships rather than sitting in the repo

`typedoc-plugin-markdown.schema.json` is gitignored but listed in the package's `files`, and regenerated by `prepublishOnly` on every publish. So it is built fresh at release time and lands in consumers' `node_modules`. Confirmed against the real tarball:

```bash
npm pack typedoc-plugin-markdown@4.13.0
```

The committed `docs/public/schema.json` still holds the full sentence, which is why this was not visible in the repo — that copy dates from `7d46ac25` (2026-01-13) and predates whatever generator update introduced the truncation.

## Diff

- `declarations.ts` — the one-line fix.
- `src/types/options.ts` — regenerated.
- `docs/public/schema.json` — only picks up `expandParameters`, whose description has been stale since 2026-07-21. Its `entryModule` text was already correct.

## Verification

- Both generated schemas inspected directly, including the gitignored one that ships: `"in favour of the `@mergeModuleWith` tag."`
- `npm run test --workspace typedoc-plugin-markdown` — 225 passing, no snapshot files added, changed or deleted.
- `npm run lint --workspace typedoc-plugin-markdown` clean.
- `npx changeset status` bumps `typedoc-plugin-markdown` alone.

Merging this cuts a `4.13.1`, which will be the first release to exercise the pull-request-based changelog dating from #897.
